### PR TITLE
Fix: Define MPIX_BFLOAT16 datatype if it is not defined for mpi headers

### DIFF
--- a/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupMPI.cpp
@@ -1,5 +1,8 @@
 #include <torch/csrc/distributed/c10d/ProcessGroupMPI.hpp>
-
+// Define the bfloat16 MPI datatype if it's not already defined
+#ifndef MPIX_BFLOAT16
+#define MPIX_BFLOAT16 ((MPI_Datatype)0x4c00024c)
+#endif
 #ifdef USE_C10D_MPI
 
 #include <iostream>


### PR DESCRIPTION
Fixes missed Bfloat16 datatype initialization if it is not detected from the underlying MPI headers. The MPIX_BFLOAT16 value is taken from the `mpi.h` file of the `include` directory of the MPI library
